### PR TITLE
mapObjectKeys-refactor: Amend mapObjectKeys signature

### DIFF
--- a/src/mapObjectKeys.ts
+++ b/src/mapObjectKeys.ts
@@ -7,15 +7,15 @@ import nonEmptyArray from './nonEmptyArray';
 
 type MappableObject = IndexableAny | IndexableAny[];
 
-const mapObjectKeys: Curry<[MappableObject, FuncSpreadT<string | number>], MappableObject> = curry(
-  <T extends MappableObject>(val: T, f: FuncSpreadT<string | number>): MappableObject => {
+const mapObjectKeys: Curry<[FuncSpreadT<string | number>, MappableObject], MappableObject> = curry(
+  <T extends MappableObject>(f: FuncSpreadT<string | number>, val: T): MappableObject => {
     if (isObject(val)) {
       return Object.keys(val).reduce((memo: IndexableAny, key: string | number): MappableObject => {
-        memo[f(key)] = nonEmptyObject(val[key]) || nonEmptyArray(val[key]) ? mapObjectKeys(val[key], f) : val[key];
+        memo[f(key)] = nonEmptyObject(val[key]) || nonEmptyArray(val[key]) ? mapObjectKeys(f, val[key]) : val[key];
         return memo;
       }, {});
     } else if (isArray(val)) {
-      return val?.map(<A extends T>(v: A) => (nonEmptyObject<A>(v) ? mapObjectKeys(v, f) : v));
+      return val?.map(<A extends T>(v: A) => (nonEmptyObject<A>(v) ? mapObjectKeys(f, v) : v));
     } else {
       return val;
     }

--- a/src/snakeCase.ts
+++ b/src/snakeCase.ts
@@ -1,0 +1,8 @@
+const snakeCase: (val: string) => string = (val: string): string =>
+  val
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-zA-Z0-9\p{L}]+/gu, '_')
+    .replace(/(\s_)/g, (match, p1) => p1.trimStart());
+
+export default snakeCase;

--- a/test/mapObjectKeys.test.ts
+++ b/test/mapObjectKeys.test.ts
@@ -40,6 +40,6 @@ test.each([
       booBaz: ['a b', 'b c', 'c d', { doOmer: 'a', boOm: ['a', 'b', { c: 'd', eF: ['g'] }] }]
     }
   ]
-])('it maps the %s object keys entities', (val: IndexableAny, expectedVal) => {
-  expect(mapObjectKeys(val, camelCase)).toMatchObject(expectedVal);
+])('it maps the %s object keys with camelCase', (val: IndexableAny, expectedVal) => {
+  expect(mapObjectKeys(camelCase, val)).toMatchObject(expectedVal);
 });

--- a/test/snakeCase.test.ts
+++ b/test/snakeCase.test.ts
@@ -1,0 +1,22 @@
+import snakeCase from '../src/snakeCase';
+
+test.each([
+  [ 'abc def', 'abc_def'],
+  [ 'abc-def', 'abc_def'],
+  [ 'abc_def', 'abc_def'],
+  [ 'abc!def', 'abc_def'],
+  [ 'abc@def', 'abc_def'],
+  [ 'abc%def', 'abc_def'],
+  [ 'abc^def', 'abc_def'],
+  [ 'abc&def', 'abc_def'],
+  [ 'abc*def', 'abc_def'],
+  [ 'abc(def', 'abc_def'],
+  [ 'abc)def', 'abc_def'],
+  [ 'a品cd!e f', 'a品cd_e_f'],
+  [ 'ն !w**sss', 'ն_w_sss'],
+  [ '0 a s w', '0_a_s_w'],
+  [ '0 a 1    w', '0_a_1_w'],
+  [ '0 a     1    w', '0_a_1_w']
+])('it maps the %s object keys entities', (val, expectedVal) => {
+  expect(snakeCase(val)).toBe(expectedVal);
+});


### PR DESCRIPTION
BREAKING CHANGE:
* Swap parameters of mapObjectKeys to allow for partial application
