### PR TITLE
fix-snake-casing: Correct snakeCase regex

### DIFF
--- a/src/snakeCase.ts
+++ b/src/snakeCase.ts
@@ -1,8 +1,9 @@
 const snakeCase: (val: string) => string = (val: string): string =>
   val
     .trim()
-    .toLowerCase()
-    .replace(/[^a-zA-Z0-9\p{L}]+/gu, '_')
-    .replace(/(\s_)/g, (match, p1) => p1.trimStart());
+    .replace(/[A-Z]/g, (match, offset) => `${offset > 0 ? '_' : ''}${match.toLowerCase()}`)
+    .replace(/[^a-z0-9\p{L}]+/gu, '_')
+    .replace(/(\s_)/g, (match, p1) => p1.trimStart())
+    .toLowerCase();
 
 export default snakeCase;

--- a/test/snakeCase.test.ts
+++ b/test/snakeCase.test.ts
@@ -1,6 +1,8 @@
 import snakeCase from '../src/snakeCase';
 
 test.each([
+  [ 'abcDef', 'abc_def'],
+  [ 'AbcDef', 'abc_def' ],
   [ 'abc def', 'abc_def'],
   [ 'abc-def', 'abc_def'],
   [ 'abc_def', 'abc_def'],

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -118,6 +118,8 @@ describe('camelCaseObjectKeys', () => {
 
 describe('snakeCasing', () => {
   test.each([
+    [{ abcDef: 'foo' }, { abc_def: 'foo' }],
+    [{ AbcDef: 'foo' }, { abc_def: 'foo' }],
     [{ 'abc def': 'foo' }, { abc_def: 'foo' }],
     [{ 'abc-def': 'foo' }, { abc_def: 'foo' }],
     [{ abc_def: 'foo' }, { abc_def: 'foo' }],
@@ -140,16 +142,20 @@ describe('snakeCasing', () => {
         'boo baz': ['a b', 'b c', 'c d', { 'do omer': 'a', 'bo om': ['a', 'b', { c: 'd', 'e()f': ['g'] }] }]
       },
       {
-        'boo_baz': ['a b', 'b c', 'c d', { 'do_omer': 'a', 'bo_om': ['a', 'b', { c: 'd', 'e_f': ['g'] }] }]
+        boo_baz: ['a b', 'b c', 'c d', { do_omer: 'a', bo_om: ['a', 'b', { c: 'd', e_f: ['g'] }] }]
       }
     ],
     [
       {
+        qrsTuv: 'foo',
+        KlmNop: 'foo',
         'abc()def': 'foo',
         foo_bar: { 'boo baz': 'snaz faz' },
         'boo baz': ['a b', 'b c', 'c d', { 'do omer': 'a', 'bo om': ['a', 'b', { c: 'd', 'e()f': ['g'] }] }]
       },
       {
+        qrs_tuv: 'foo',
+        klm_nop: 'foo',
         abc_def: 'foo',
         foo_bar: { boo_baz: 'snaz faz' },
         boo_baz: ['a b', 'b c', 'c d', { do_omer: 'a', bo_om: ['a', 'b', { c: 'd', e_f: ['g'] }] }]


### PR DESCRIPTION
* Add regex to replace capital alpha chars with underscores throughout
  whole string - NOTE: Converts PascalCase/camelCase implicitly